### PR TITLE
Automatic update of HelpMyStreet.Contracts to 1.1.379

### DIFF
--- a/ReportingService.VerificationService/ReportingService.VerificationService.csproj
+++ b/ReportingService.VerificationService/ReportingService.VerificationService.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.56" />
+	<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
 	<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 

--- a/ReportingService/ReportingService.Core/ReportingService.Core.csproj
+++ b/ReportingService/ReportingService.Core/ReportingService.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.56" />
+    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
     <PackageReference Include="MediatR" Version="8.0.1" />
 	<PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
   </ItemGroup>

--- a/ReportingService/ReportingService.UserService/ReportingService.UserService.csproj
+++ b/ReportingService/ReportingService.UserService/ReportingService.UserService.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.56" />
+    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a patch update of `HelpMyStreet.Contracts` to `1.1.379` from `1.1.56`
`HelpMyStreet.Contracts 1.1.379` was published at `2020-09-23T13:56:26Z`, 2 hours ago

3 project updates:
Updated `ReportingService.VerificationService\ReportingService.VerificationService.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.56`
Updated `ReportingService\ReportingService.Core\ReportingService.Core.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.56`
Updated `ReportingService\ReportingService.UserService\ReportingService.UserService.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.56`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
